### PR TITLE
chore: add CapRover deployment configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,23 @@ Visit http://localhost:3000. Seed accounts:
 - admin / admin123
 - staff / staff123
 
+## Environment Variables
+
+The backend expects the following environment variables:
+
+- `DATABASE_URL` – connection string for the PostgreSQL database.
+- `JWT_SECRET` – secret used for signing JSON Web Tokens.
+- `PORT` – optional HTTP port (defaults to `4000`).
+
+For production, it is recommended to deploy a PostgreSQL instance using CapRover's one-click app and use its connection URL for `DATABASE_URL`.
+
 ## Deploy on CapRover
 
-1. Create two apps (backend, frontend) and a PostgreSQL one-click app.
-2. For backend set env vars: `DATABASE_URL`, `JWT_SECRET`.
-3. Deploy images built from Dockerfiles.
-4. Attach persistent volume to Postgres.
+1. On the CapRover dashboard, install the PostgreSQL one-click app and note the provided connection URL.
+2. Create two apps for the backend and frontend.
+3. In the backend app, set environment variables:
+   - `DATABASE_URL` – the connection string from the one-click Postgres app.
+   - `JWT_SECRET` – any secret value used for tokens.
+4. From the `backend/` and `frontend/` directories, run `caprover deploy` to build and upload using the included `captain-definition` files.
+5. Attach a persistent volume to the Postgres app.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=postgresql://<user>:<password>@<host>:5432/<database>
+JWT_SECRET=changeme
+PORT=4000

--- a/backend/captain-definition
+++ b/backend/captain-definition
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 2,
+  "dockerfilePath": "Dockerfile",
+  "httpPort": 4000
+}

--- a/frontend/captain-definition
+++ b/frontend/captain-definition
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 2,
+  "dockerfilePath": "Dockerfile"
+}


### PR DESCRIPTION
## Summary
- add CapRover captain-definition files for backend and frontend
- document environment variables and suggest using one-click Postgres
- expand README with CapRover deployment instructions

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46c696ea08325a4a1759abf8ec132