### PR TITLE
Install OpenSSL in backend Dockerfile for Prisma

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,8 @@ ARG DATABASE_URL="postgresql://carwash:carwash@db:5432/carwash"
 ENV DATABASE_URL=$DATABASE_URL
 
 COPY package*.json ./
-RUN npm install --no-fund --no-audit
+RUN apk add --no-cache openssl \
+    && npm install --no-fund --no-audit
 COPY prisma ./prisma
 COPY src ./src
 RUN npx prisma generate && npm run build


### PR DESCRIPTION
## Summary
- Install OpenSSL in backend Dockerfile before npm install and Prisma generate

## Testing
- `npm test`
- `docker build -f backend/Dockerfile backend` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e60e66788325b750fc9890648628