### PR TITLE
Add Prisma seed script using ts-node

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,7 @@
         "@types/jsonwebtoken": "^9.0.2",
         "@types/node": "^20.11.30",
         "prisma": "^5.15.0",
+        "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.0"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,26 +9,30 @@
     "start": "node dist/index.js",
     "test": "echo 'no tests'"
   },
+  "prisma": {
+    "seed": "node --loader ts-node/esm prisma/seed.ts"
+  },
   "dependencies": {
-    "express": "^4.18.2",
-    "cors": "^2.8.5",
-    "cookie-parser": "^1.4.6",
-    "jsonwebtoken": "^9.0.2",
-    "bcryptjs": "^2.4.3",
-    "socket.io": "^4.7.5",
-    "socket.io-client": "^4.7.5",
     "@prisma/client": "^5.15.0",
-    "json2csv": "^5.0.7"
+    "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "json2csv": "^5.0.7",
+    "jsonwebtoken": "^9.0.2",
+    "socket.io": "^4.7.5",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
-    "typescript": "^5.4.0",
-    "ts-node-dev": "^2.0.0",
-    "@types/express": "^4.17.21",
-    "@types/node": "^20.11.30",
-    "@types/cors": "^2.8.17",
     "@types/bcryptjs": "^2.4.2",
-    "@types/jsonwebtoken": "^9.0.2",
     "@types/cookie-parser": "^1.4.4",
-    "prisma": "^5.15.0"
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.2",
+    "@types/node": "^20.11.30",
+    "prisma": "^5.15.0",
+    "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- install ts-node and add Prisma seed script using ts-node loader

## Testing
- `npm run build`
- `npx prisma db seed` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b2a4ac088325a0276100b1a9cab6