### PR TITLE
Configure frontend API base URL and proxy

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,11 @@
+# Example frontend environment configuration
+# Copy this file to .env and adjust the value based on your deployment target.
+#
+# When deploying with Docker or CapRover, set VITE_API_URL to the public URL of the
+# backend service so that the static frontend bundle can reach the API.
+# For CapRover this is typically the HTTPS endpoint of your backend app, e.g.:
+#   https://your-backend.example.com
+# For local Docker Compose usage you can rely on the built-in Nginx /api proxy
+# (no override necessary), but you may set this value if your backend is hosted
+# elsewhere.
+VITE_API_URL=https://your-backend.example.com

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,5 +7,6 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx","-g","daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,20 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location /api/ {
+    proxy_pass http://backend:4000/api/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,6 +1,11 @@
 import axios from 'axios';
 
+const baseURL =
+  import.meta.env.VITE_API_URL ||
+  (typeof window !== 'undefined' ? window.location.origin : '');
+
 const instance = axios.create({
+  baseURL,
   withCredentials: true,
 });
 


### PR DESCRIPTION
## Summary
- read the API base URL from `VITE_API_URL` with a browser-origin fallback
- add a frontend `.env.example` that documents how to set `VITE_API_URL`
- ship a custom nginx config that proxies `/api` requests to the backend service

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce67311cf883258bf8872705481801